### PR TITLE
Inferred partitions

### DIFF
--- a/macros/plugins/spark/helpers/recover_partitions.sql
+++ b/macros/plugins/spark/helpers/recover_partitions.sql
@@ -2,7 +2,7 @@
     {# https://docs.databricks.com/sql/language-manual/sql-ref-syntax-ddl-alter-table.html #}
 
     {% set ddl %}
-    {%- if (source_node.external.partitions or source_node.external.partitions == []) and source_node.external.using and source_node.external.using|lower != 'delta' -%}
+    {%- if (source_node.external.partitions or source_node.external.recover_partitions) and source_node.external.using and source_node.external.using|lower != 'delta' -%}
         ALTER TABLE {{ source(source_node.source_name, source_node.name) }} RECOVER PARTITIONS
     {%- endif -%}
     {% endset %}

--- a/macros/plugins/spark/helpers/recover_partitions.sql
+++ b/macros/plugins/spark/helpers/recover_partitions.sql
@@ -2,7 +2,7 @@
     {# https://docs.databricks.com/sql/language-manual/sql-ref-syntax-ddl-alter-table.html #}
 
     {% set ddl %}
-    {%- if source_node.external.partitions and source_node.external.using and source_node.external.using|lower != 'delta' -%}
+    {%- if (source_node.external.partitions or source_node.external.partitions == []) and source_node.external.using and source_node.external.using|lower != 'delta' -%}
         ALTER TABLE {{ source(source_node.source_name, source_node.name) }} RECOVER PARTITIONS
     {%- endif -%}
     {% endset %}

--- a/sample_sources/spark.yml
+++ b/sample_sources/spark.yml
@@ -34,7 +34,8 @@ sources:
 - name: event_inferred_schema
         description: "Snowplow events stored as partitioned parquet files in HDFS with inferred schema"
         external:
-          # Path can contain partitions such as: hdfs://.../events/my_partition=2022-03-01/events1.parquet
+          # File path can contain partitions such as: hdfs://.../events/my_partition=2022-03-01/events1.parquet
+          # These partitions are excluded from 'location'.
           location: 'hdfs://.../events/'
           using: parquet
 

--- a/sample_sources/spark.yml
+++ b/sample_sources/spark.yml
@@ -30,3 +30,14 @@ sources:
           - name: contexts
             data_type: string
             description: "Contexts attached to event by Tracker"
+
+- name: event_inferred_schema
+        description: "Snowplow events stored as partitioned parquet files in HDFS with inferred schema"
+        external:
+          # Path can contain partitions such as: hdfs://.../events/my_partition=2022-03-01/events1.parquet
+          location: 'hdfs://.../events/'
+          using: parquet
+
+          # Setting recover_partitions to true causes partitions to be refreshed,
+          # even though partitions are not explicitly specified.
+          recover_partitions: true


### PR DESCRIPTION
Add the option to run ALTER TABLE RECOVER PARTITIONS to spark even if partitions are not explicitly specified. This is useful when working with inferred partitions.